### PR TITLE
bugfix: pixelated/low quality button image

### DIFF
--- a/virtualjoystick/src/main/java/io/github/controlwear/virtual/joystick/android/JoystickView.java
+++ b/virtualjoystick/src/main/java/io/github/controlwear/virtual/joystick/android/JoystickView.java
@@ -365,7 +365,7 @@ public class JoystickView extends View
         mBorderRadius = (int) (d / 2 * mBackgroundSizeRatio);
 
         if (mButtonBitmap != null)
-            mButtonBitmap = Bitmap.createScaledBitmap(mButtonBitmap, mButtonRadius * 2, mButtonRadius * 2, false);
+            mButtonBitmap = Bitmap.createScaledBitmap(mButtonBitmap, mButtonRadius * 2, mButtonRadius * 2, true);
     }
 
 
@@ -602,7 +602,7 @@ public class JoystickView extends View
                             mButtonBitmap,
                             mButtonRadius * 2,
                             mButtonRadius * 2,
-                            false);
+                            true);
                 }
 
                 if (mPaintBitmapButton != null)


### PR DESCRIPTION
If custom image was used as a joystick image, the image had very low quality. Please verify on actual device, as this bug is very hard to notice on emulator.

Solution: https://stackoverflow.com/a/4821519/797321